### PR TITLE
Add support for certificate-based authentication

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -15,6 +15,7 @@
 #
 # @author: Henry Gessau, Cisco Systems
 # @author: Ivar Lazzaro (ivar-lazzaro), Cisco Systems Inc.
+# @author: Amit Bose (amibose@cisco.com), Cisco Systems Inc.
 
 import collections
 import contextlib
@@ -24,6 +25,9 @@ import time
 
 import requests
 import requests.exceptions as rexc
+
+from OpenSSL.crypto import FILETYPE_PEM, load_privatekey, sign
+import base64
 
 from apicapi import exceptions as cexc
 
@@ -278,11 +282,15 @@ class ManagedObjectClass(object):
 
 
 class ApicSession(object):
+    HTTP_GET = 'GET'
+    HTTP_POST = 'POST'
+    HTTP_PUT = 'PUT'
+    HTTP_DELETE = 'DELETE'
 
     """Manages a session with the APIC."""
 
-    def __init__(self, hosts, usr, pwd, ssl, verify=False,
-                 request_timeout=None):
+    def __init__(self, hosts, usr, pwd, ssl, verify=False, request_timeout=None,
+                 cert_name=None, private_key_file=None):
         protocol = 'https' if ssl else 'http'
         self.api_base = collections.deque(['%s://%s/api' % (protocol, host)
                                            for host in hosts])
@@ -297,8 +305,12 @@ class ApicSession(object):
         self.authentication = None
         self.username = None
         self.password = None
+        self.cert_name = None
+        self.private_key = None
         if usr and pwd:
             self.login(usr, pwd)
+        elif usr and cert_name and private_key_file:
+            self.set_private_key(usr, cert_name, private_key_file)
         # Init last call to current time
         self.last_call = time.time()
         # 30 ms sleep time
@@ -306,16 +318,18 @@ class ApicSession(object):
 
     def _do_request(self, request, url, **kwargs):
         """Use this method to wrap all the http requests."""
+        req_call = self._get_request_call(request)
+        self._calculate_signature(request, url, kwargs)
         for x in range(len(self.api_base)):
             try:
-                return request(self.api_base[0] + url, verify=self.verify,
-                               timeout=self.request_timeout, **kwargs)
+                return req_call(self.api_base[0] + url, verify=self.verify,
+                                timeout=self.request_timeout, **kwargs)
             except FALLBACK_EXCEPTIONS as ex:
                 LOG.info(('%s, falling back to a '
                           'new address'), ex.message)
                 self.api_base.rotate(-1)
                 LOG.info(('New controller address: %s '), self.api_base[0])
-        return request(self.api_base[0] + url, **kwargs)
+        return req_call(self.api_base[0] + url, verify=self.verify, **kwargs)
 
     @staticmethod
     def _make_data(key, **attrs):
@@ -349,6 +363,8 @@ class ApicSession(object):
 
     def _check_session(self):
         """Check that we are logged in and ensure the session is active."""
+        if self._is_cert_auth():
+            return      # Certificate based authentication is session-less
         if not self.authentication:
             raise cexc.ApicSessionNotLoggedIn
         if time.time() > self.session_deadline:
@@ -390,7 +406,8 @@ class ApicSession(object):
                 err_code = '[code for APIC error not found]'
                 err_text = '[text for APIC error not found]'
             # If invalid token then re-login and retry once
-            if not refreshed and (err_code in REFRESH_CODES):
+            if not refreshed and (err_code in REFRESH_CODES) and \
+               not self._is_cert_auth():
                 self.login()
                 return self._send(request, url, data=data, refreshed=True)
             if not accepted and response.status_code == 202:
@@ -403,63 +420,75 @@ class ApicSession(object):
                                          err_text=err_text, err_code=err_code)
         return imdata
 
+    def _get_request_call(self, request):
+        if request == ApicSession.HTTP_GET:
+            return self.session.get
+        elif request == ApicSession.HTTP_POST:
+            return self.session.post
+        elif request == ApicSession.HTTP_DELETE:
+            return self.session.delete
+        elif request == ApicSession.HTTP_PUT:
+            return self.session.put
+        else:
+            return None
+
     # REST requests
 
     def get_data(self, request):
         """Retrieve generic data from the server."""
         self._check_session()
         url = self._api_url(request)
-        return self._send(self.session.get, url)
+        return self._send(ApicSession.HTTP_GET, url)
 
     def get_mo(self, mo, *args):
         """Retrieve a managed object by its distinguished name."""
         self._check_session()
         url = self._mo_url(mo, *args) + '?query-target=self'
-        return self._send(self.session.get, url)
+        return self._send(ApicSession.HTTP_GET, url)
 
     def get_mo_subtree(self, mo, *args, **kwargs):
         self._check_session()
         url = self._subtree_url(mo, *args, **kwargs)
-        return self._send(self.session.get, url)
+        return self._send(ApicSession.HTTP_GET, url)
 
     def list_mo(self, mo, **kwargs):
         """Retrieve the list of managed objects for a class."""
         self._check_session()
         url = self._qry_url(mo) + '?' + self._bulid_target_filter(mo, **kwargs)
-        return self._send(self.session.get, url)
+        return self._send(ApicSession.HTTP_GET, url)
 
     def post_data(self, request, data):
         """Post generic data to the server."""
         self._check_session()
         url = self._api_url(request)
-        return self._send(self.session.post, url, data=data)
+        return self._send(ApicSession.HTTP_POST, url, data=data)
 
     def post_mo(self, mo, *params, **data):
         """Post data for a managed object to the server."""
         self._check_session()
         url = self._mo_url(mo, *params)
         data = self._make_data(mo.klass_name, **data)
-        return self._send(self.session.post, url, data=data)
+        return self._send(ApicSession.HTTP_POST, url, data=data)
 
     def post_body(self, mo, data, *params):
         """Post mo with pre made body."""
         self._check_session()
         url = self._mo_url(mo, *params)
-        return self._send(self.session.post, url, data=data)
+        return self._send(ApicSession.HTTP_POST, url, data=data)
 
     def delete_mo(self, mo, *params):
         self._check_session()
         url = self._mo_url(mo, *params)
-        return self._send(self.session.delete, url)
+        return self._send(ApicSession.HTTP_DELETE, url)
 
     def GET(self, url, data=None):
-        return self._send(self.session.get, url, data=data)
+        return self._send(ApicSession.HTTP_GET, url, data=data)
 
     def POST(self, url, data=None):
-        return self._send(self.session.post, url, data=data)
+        return self._send(ApicSession.HTTP_POST, url, data=data)
 
     def DELETE(self, url, data=None):
-        return self._send(self.session.delete, url, data=data)
+        return self._send(ApicSession.HTTP_DELETE, url, data=data)
 
     def delete_class(self, klass):
         nodes = self.GET('/node/class/%s.json' % klass)
@@ -490,6 +519,28 @@ class ApicSession(object):
             attributes = imdata[0]['error']['attributes']
         return attributes
 
+    def _calculate_signature(self, request, url, kwargs):
+        """ Sign the request using private key and put the result in cookies"""
+        if self._is_cert_auth():
+            if url.endswith('?'):
+                url = url[:-1]
+            url = url.replace('//', '/')
+            payLoad = request + '/api' + url + kwargs.get('data', '')
+            signedDigest = sign(self.private_key, payLoad, 'sha256')
+            signature = base64.b64encode(signedDigest)
+            kwargs['cookies'] = {
+                'APIC-Request-Signature' :  signature,
+                'APIC-Certificate-Algorithm' : 'v1.0',
+                'APIC-Certificate-Fingerprint' : 'fingerprint',
+                'APIC-Certificate-DN' : self._get_cert_dn(self.username,
+                                                          self.cert_name)}
+
+    def _is_cert_auth(self):
+        return not self.password and self.cert_name and self.private_key
+
+    def _get_cert_dn(self, usr, cert_name):
+        return ("uni/userext/user-%s/usercert-%s") % (usr, cert_name)
+
     def login(self, usr=None, pwd=None):
         """Log in to controller. Save user name and authentication."""
         usr = usr or self.username
@@ -499,7 +550,7 @@ class ApicSession(object):
         self.cookie = {}
 
         try:
-            response = self._do_request(self.session.post, url, data=name_pwd)
+            response = self._do_request(ApicSession.HTTP_POST, url, data=name_pwd)
         except rexc.Timeout:
             raise cexc.ApicHostNoResponse(url=url)
         attributes = self._save_cookie('aaaLogin', response)
@@ -515,10 +566,51 @@ class ApicSession(object):
                                          err_text=attributes['text'],
                                          err_code=attributes['code'])
 
+    def set_private_key(self, usr, cert_name, private_key_file):
+        """Set the X.509 private key used for session-less REST calls"""
+        url = self._api_url('mo/%s' % self._get_cert_dn(usr, cert_name))
+
+        try:
+            with open(private_key_file) as key_file:
+                private_key = load_privatekey(FILETYPE_PEM, key_file.read())
+        except Exception, e:
+            LOG.error("Failed to load private key from file %s: %s" %
+                      (private_key_file, e))
+            raise
+
+        old_username = self.username
+        old_cert_name = self.cert_name
+        old_private_key = self.private_key
+
+        self.username = usr
+        self.cert_name = cert_name
+        self.private_key = private_key
+        # Verify that the cert-name and key are ok
+        try:
+            response = self._do_request(ApicSession.HTTP_GET, url)
+        except rexc.Timeout:
+            self.username = old_username
+            self.cert_name = old_cert_name
+            self.private_key = old_private_key
+            raise cexc.ApicHostNoResponse(url=url)
+
+        if response.status_code != requests.codes.ok:
+            self.username = old_username
+            self.cert_name = old_cert_name
+            self.private_key = old_private_key
+            attributes = response.json().get('imdata')[0]['error']['attributes']
+            raise cexc.ApicResponseNotOk(request=url,
+                                         status=response.status_code,
+                                         reason=response.reason,
+                                         err_text=attributes['text'],
+                                         err_code=attributes['code'])
+
     def refresh(self):
         """Called when a session has timed out or almost timed out."""
+        if self._is_cert_auth():
+            return          # Certificate-based calls are session-less
         url = self._api_url('aaaRefresh')
-        response = self._do_request(self.session.get, url,
+        response = self._do_request(ApicSession.HTTP_GET, url,
                                     cookies=self.cookie)
         attributes = self._save_cookie('aaaRefresh', response)
         if response.status_code == requests.codes.ok:
@@ -719,14 +811,15 @@ class RestClient(ApicSession):
 
     def __init__(self, log, system_id, hosts, usr=None, pwd=None, ssl=True,
                  scope_names=True, renew_names=True, verify=False,
-                 request_timeout=None):
+                 request_timeout=None, cert_name=None, private_key_file=None):
         """Establish a session with the APIC."""
         if not scope_names:
             ManagedObjectClass.scope_exceptions = None
         global LOG
         LOG = log.getLogger(__name__)
         super(RestClient, self).__init__(hosts, usr, pwd, ssl, verify,
-                                         request_timeout)
+                                         request_timeout, cert_name,
+                                         private_key_file)
         ManagedObjectClass.scope = '_' + system_id + '_'
         self.dn_manager = DNManager()
         self.renew_names = renew_names

--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -114,7 +114,9 @@ class APICManager(object):
             verify=self.apic_config.verify_ssl_certificate,
             request_timeout=self.apic_config.apic_request_timeout,
             cert_name=self.apic_config.certificate_name,
-            private_key_file=self.apic_config.private_key_file
+            private_key_file=self.apic_config.private_key_file,
+            sign_algo=self.apic_config.signature_verification_algorithm,
+            sign_hash=self.apic_config.signature_hash_type
         )
 
         self.phys_domain_dn = self.apic.physDomP.dn(

--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -16,6 +16,7 @@
 # @author: Ivar Lazzaro (ivar-lazzaro), Cisco Systems Inc.
 # @author: Mandeep Dhami (madhami@cisco.com), Cisco Systems Inc.
 # @author: Arvind Somya (asomya@cisco.com), Cisco Systems Inc.
+# @author: Amit Bose (amibose@cisco.com), Cisco Systems Inc.
 
 from apicapi import apic_client
 from apicapi import apic_mapper
@@ -111,7 +112,9 @@ class APICManager(object):
             scope_names=self.apic_config.scope_names,
             renew_names=self.apic_config.renew_names,
             verify=self.apic_config.verify_ssl_certificate,
-            request_timeout=self.apic_config.apic_request_timeout
+            request_timeout=self.apic_config.apic_request_timeout,
+            cert_name=self.apic_config.certificate_name,
+            private_key_file=self.apic_config.private_key_file
         )
 
         self.phys_domain_dn = self.apic.physDomP.dn(

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -14,6 +14,7 @@
 #    under the License.
 #
 # @author: Ivar Lazzaro (ivar-lazzaro), Cisco Systems Inc.
+# @author: Amit Bose (amibose@cisco.com), Cisco Systems Inc.
 
 import re
 import sys
@@ -68,6 +69,11 @@ apic_opts = [
                help=("Number of seconds after which the requests to APIC "
                      "timeout in case of no response received. This is value "
                      "affects both read and connect timeout.")),
+    cfg.StrOpt('private_key_file', default=None,
+               help=("Filename of user's private key file to be used for "
+                     "authenticating requests")),
+    cfg.StrOpt('certificate_name', default=None,
+               help=("Name given to user's X.509 certificate in APIC")),
 ]
 
 APP_PROFILE_REGEX = "[a-zA-Z0-9_.:-]+"
@@ -150,6 +156,15 @@ def valid_name_strategy(key, value):
     if value not in valid:
         util.re("Allowed values: %s" % str(valid))
 
+def valid_file(key, value):
+    if value is None:
+        return
+    try:
+        with open(value) as f:
+            pass
+    except Exception, e:
+        util = ConfigValidator.RaiseUtils(value, key)
+        util.re("Bad file-name: %s: %s" % (value, e))
 
 class ConfigValidator(object):
     """Configuration validator for APICAPI.
@@ -176,6 +191,7 @@ class ConfigValidator(object):
         'apic_function_profile': [valid_apic_name],
         'apic_lacp_profile': [valid_apic_name],
         'apic_vlan_range': [valid_range],
+        'private_key_file': [valid_file],
     }
 
     class RaiseUtils(object):

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -69,11 +69,15 @@ apic_opts = [
                help=("Number of seconds after which the requests to APIC "
                      "timeout in case of no response received. This is value "
                      "affects both read and connect timeout.")),
-    cfg.StrOpt('private_key_file', default=None,
+    cfg.StrOpt('private_key_file',
                help=("Filename of user's private key file to be used for "
                      "authenticating requests")),
-    cfg.StrOpt('certificate_name', default=None,
+    cfg.StrOpt('certificate_name',
                help=("Name given to user's X.509 certificate in APIC")),
+    cfg.StrOpt('signature_verification_algorithm',
+               help=("Algorithm used by APIC for signature verification")),
+    cfg.StrOpt('signature_hash_type',
+               help=("Hashing algorithm to use for calculating signature")),
 ]
 
 APP_PROFILE_REGEX = "[a-zA-Z0-9_.:-]+"

--- a/apicapi/tests/unit/common/test_apic_common.py
+++ b/apicapi/tests/unit/common/test_apic_common.py
@@ -15,10 +15,14 @@
 #
 # @author: Henry Gessau, Cisco Systems
 # @author: Ivar Lazzaro (ivar-lazzaro), Cisco Systems Inc.
+# @author: Amit Bose (amibose@cisco.com), Cisco Systems Inc.
 
 import contextlib
 import mock
 import requests
+import tempfile
+from OpenSSL import crypto
+import base64
 
 from oslo.config import cfg
 
@@ -33,6 +37,7 @@ APIC_HOSTS = ['fake.controller.local']
 APIC_PORT = 7580
 APIC_USR = 'notadmin'
 APIC_PWD = 'topsecret'
+APIC_USR_CERT_NAME = 'notadmin-cert'
 
 APIC_TENANT = 'citizen14'
 APIC_NETWORK = 'network99'
@@ -80,6 +85,22 @@ class ControllerMixin(object):
         self.reset_reponses()
         self.log = mock.Mock()
 
+    def create_pvt_key_file(self):
+        self.clean_up_pvt_key_file()
+        self.pvt_key_file = tempfile.NamedTemporaryFile()
+        pk = crypto.PKey()
+        pk.generate_key(crypto.TYPE_RSA, 1024)
+        self.pvt_key_file.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pk))
+        self.pvt_key_file.flush()
+        self.certificate = crypto.X509()
+        self.certificate.set_pubkey(pk)
+        self.certificate.sign(pk, 'sha256')
+        return self.pvt_key_file.name
+
+    def clean_up_pvt_key_file(self):
+        if hasattr(self, 'pvt_key_file'):
+            self.pvt_key_file.close()
+
     def reset_reponses(self, req=None):
         # Clear all staged responses.
         reqs = req and [req] or ['post', 'get']  # Both if none specified.
@@ -93,6 +114,40 @@ class ControllerMixin(object):
             requests.Session.post = responses
         elif req == 'get':
             requests.Session.get = responses
+
+    def enable_signature_check(self):
+        self.saved_get_responder = requests.Session.get
+        self.saved_post_responder = requests.Session.post
+        requests.Session.get = \
+            mock.MagicMock(side_effect=self._verify_and_respond_for_get)
+        requests.Session.post = \
+            mock.MagicMock(side_effect=self._verify_and_respond_for_post)
+
+    def _verify_and_respond_for_get(self, *args, **kwargs):
+        self._verify_signature('GET', *args, **kwargs)
+        return self.saved_get_responder(*args, **kwargs)
+
+    def _verify_and_respond_for_post(self, *args, **kwargs):
+        self._verify_signature('POST', *args, **kwargs)
+        return self.saved_post_responder(*args, **kwargs)
+
+    def _verify_signature(self, req, *args, **kwargs):
+        """ Throws exception if verification fails """
+        cookies = kwargs.get('cookies', {})
+        if 'APIC-Request-Signature' not in cookies:
+            return
+        url = args[0]
+        payload = req + url[url.find('/api'):] + kwargs.get('data', '')
+        cert_dn = 'uni/userext/user-%s/usercert-%s' % \
+            (APIC_USR, APIC_USR_CERT_NAME)
+        if cookies.get('APIC-Certificate-DN') != cert_dn:
+            raise Exception("Certificate DN mismatch")
+        if cookies.get('APIC-Certificate-Algorithm') != 'v1.0' or \
+           cookies.get('APIC-Certificate-Fingerprint') != 'fingerprint':
+            raise Exception("Signature verification algorithm mismatch")
+        crypto.verify(self.certificate,
+                      base64.b64decode(cookies.get('APIC-Request-Signature')),
+                      payload, 'sha256')
 
     def mock_response_for_post(self, mo, **attrs):
         attrs['debug_mo'] = mo  # useful for debugging
@@ -143,6 +198,9 @@ class ControllerMixin(object):
         # APIC Manager tests are based on authenticated session
         self.mock_response_for_post('aaaLogin', userName=APIC_USR,
                                     token='ok', refreshTimeoutSeconds=timeout)
+
+    def mock_response_for_certificate_fetch(self, cert_name):
+        self.mock_response_for_get('aaaUserCert', name=cert_name)
 
     def assert_responses_drained(self, req=None):
         """Fail if all the expected responses have not been consumed."""


### PR DESCRIPTION
To use certificate-based ("password-less") authentication,
every request sent to APIC needs to signed with the user's
private key and the digest placed into HTTP cookies. In this
change, class ApicSession allows specifying the private key
to be used and adds the necessary plumbing to sign every
request.

Signed-off-by: Amit Bose <bose@noironetworks.com>