### PR TITLE
vmware integration feature

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -185,7 +185,7 @@ class ManagedObjectClass(object):
         'fabricPathEp': ManagedObjectName('fabricPathEpCont', 'pathep-%s',
                                           False),
         'fabricNode': ManagedObjectName('fabricPod', 'node-%s', False),
-        'vmmProvP': ManagedObjectName(None, 'vmmp-OpenStack', False),
+        'vmmProvP': ManagedObjectName(None, 'vmmp-%s', False),
         'vmmDomP': ManagedObjectName('vmmProvP', 'dom-%s'),
         'vmmUsrAccP': ManagedObjectName('vmmDomP', 'usracc-%s'),
         'vmmCtrlrP': ManagedObjectName('vmmDomP', 'ctrlr-%s'),

--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -57,7 +57,7 @@ LOG = None
 # VMM type supported
 APIC_VMM_TYPE_OPENSTACK = 'OpenStack'
 APIC_VMM_TYPE_VMWARE = 'VMware'
-APIC_VMM_TYPE_SUPPORTED = [APIC_VMM_TYPE_OPENSTACK, APIC_VMM_TYPE_VMWARE]
+APIC_VMM_TYPES_SUPPORTED = [APIC_VMM_TYPE_OPENSTACK, APIC_VMM_TYPE_VMWARE]
 
 
 class APICManager(object):
@@ -205,7 +205,7 @@ class APICManager(object):
                 if vmm_dom is None:
                     raise cexc.ApicVmwareVmmDomainNotConfigured(name=vmm_name)
             else:
-                raise cexc.ApicVmmTypeNotSupported(type=self.apic_vmm_type, list=APIC_VMM_TYPE_SUPPORTED)
+                raise cexc.ApicVmmTypeNotSupported(type=self.apic_vmm_type, list=APIC_VMM_TYPES_SUPPORTED)
 
         # Create entity profile
         ent_name = self.apic_config.apic_entity_profile

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -42,6 +42,10 @@ apic_opts = [
     cfg.StrOpt('apic_model',
                default='neutron.plugins.ml2.drivers.cisco.apic.apic_model'),
     cfg.BoolOpt('use_vmm', default=False),
+    cfg.StrOpt('apic_vmm_type',
+               default='OpenStack',
+               help=("The vmm type of choice. Currently we only support "
+                     "either OpenStack or VMware")),
     cfg.StrOpt('apic_multicast_ns_name',
                default='${apic_system_id}_mcast_ns',
                help=("Name for the multicast namespace to be used for "
@@ -204,6 +208,7 @@ class ConfigValidator(object):
         'apic_lacp_profile': [valid_apic_name],
         'apic_vlan_range': [valid_range],
         'private_key_file': [valid_file],
+        'apic_vmm_type': [valid_apic_name],
     }
 
     class RaiseUtils(object):

--- a/apicapi/exceptions.py
+++ b/apicapi/exceptions.py
@@ -94,3 +94,14 @@ class ApicMultipleVlanRanges(ApicException):
 class ApicInvalidTransactionMultipleRoot(ApicException):
     """The switch and port for the specified host are not configured."""
     message = "An apic transaction cannot start from multiple root nodes"
+
+
+class ApicVmwareVmmDomainNotConfigured(ApicException):
+    """The VMware VMM domain doesn't exist in APIC."""
+    message = "VMware VMM Domain '%(name)s' does not exist in APIC"
+
+
+class ApicVmmTypeNotSupported(ApicException):
+    """The APIC VMM type is not supported at this moment."""
+    message = ("VMM type '%(type)s' is not supported. Currently we only "
+               "support either OpenStack or VMware.")

--- a/apicapi/exceptions.py
+++ b/apicapi/exceptions.py
@@ -104,4 +104,4 @@ class ApicVmwareVmmDomainNotConfigured(ApicException):
 class ApicVmmTypeNotSupported(ApicException):
     """The APIC VMM type is not supported at this moment."""
     message = ("VMM type '%(type)s' is not supported. Currently we only "
-               "support either OpenStack or VMware.")
+               "support '%(list)s'.")

--- a/apicapi/tests/unit/test_apic_manager.py
+++ b/apicapi/tests/unit/test_apic_manager.py
@@ -207,6 +207,23 @@ class TestCiscoApicManager(base.BaseTestCase,
         self.assertRaises(cexc.ApicResponseNotOk,
                           self.mgr.ensure_infra_created_on_apic)
 
+    def test_good_vmware_vmm_domain_inside_ensure_infra_created_on_apic(self):
+        self.override_config('apic_vmm_type', 'VMware', 'ml2_cisco_apic')
+        self.override_config('apic_domain_name', 'good_name', 'ml2_cisco_apic')
+        self.mock_response_for_get('vmmDomP', dn="good_dn")
+
+    def test_nonexist_vmware_vmm_domain_inside_ensure_infra_created_on_apic(self):
+        self.override_config('apic_vmm_type', 'VMware', 'ml2_cisco_apic')
+        self.override_config('apic_domain_name', 'bad_name', 'ml2_cisco_apic')
+        self.mock_response_for_get('vmmDomP')
+        self.assertRaises(cexc.ApicVmwareVmmDomainNotConfigured,
+                          self.mgr.ensure_infra_created_on_apic)
+
+    def test_wrong_vmm_type_inside_ensure_infra_created_on_apic(self):
+        self.override_config('apic_vmm_type', 'wrong_type', 'ml2_cisco_apic')
+        self.assertRaises(cexc.ApicVmmTypeNotSupported,
+                          self.mgr.ensure_infra_created_on_apic)
+
     def test_ensure_context_enforced_new_ctx(self):
         self.mock_response_for_post(self.get_top_container(
             self.mgr.apic.fvCtx.mo))

--- a/apicapi/tests/unit/test_apic_manager.py
+++ b/apicapi/tests/unit/test_apic_manager.py
@@ -208,19 +208,22 @@ class TestCiscoApicManager(base.BaseTestCase,
                           self.mgr.ensure_infra_created_on_apic)
 
     def test_good_vmware_vmm_domain_inside_ensure_infra_created_on_apic(self):
-        self.override_config('apic_vmm_type', 'VMware', 'ml2_cisco_apic')
+        np_create_for_switch, pp_create_for_switch = (
+            self._ensure_infra_created_seq1_setup())
+        self.mgr.apic_vmm_type = 'VMware'
         self.override_config('apic_domain_name', 'good_name', 'ml2_cisco_apic')
         self.mock_response_for_get('vmmDomP', dn="good_dn")
+        self.mgr.ensure_infra_created_on_apic()
 
     def test_nonexist_vmware_vmm_domain_inside_ensure_infra_created_on_apic(self):
-        self.override_config('apic_vmm_type', 'VMware', 'ml2_cisco_apic')
+        self.mgr.apic_vmm_type = 'VMware'
         self.override_config('apic_domain_name', 'bad_name', 'ml2_cisco_apic')
         self.mock_response_for_get('vmmDomP')
         self.assertRaises(cexc.ApicVmwareVmmDomainNotConfigured,
                           self.mgr.ensure_infra_created_on_apic)
 
     def test_wrong_vmm_type_inside_ensure_infra_created_on_apic(self):
-        self.override_config('apic_vmm_type', 'wrong_type', 'ml2_cisco_apic')
+        self.mgr.apic_vmm_type = 'wrong_type'
         self.assertRaises(cexc.ApicVmmTypeNotSupported,
                           self.mgr.ensure_infra_created_on_apic)
 


### PR DESCRIPTION
1. support vmm type VMware in addition to OpenStack
2. define a new config item apic_vmm_type (either OpenStack or VMware, defaults to OpenStack) 
3. introduce 2 new exception classes 
4. added 3 test cases for this feature work