### PR TITLE
Add support for external-routing domain objects

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -100,6 +100,7 @@ class ManagedObjectClass(object):
         'l3extOut': ManagedObjectName('fvTenant', 'out-%(name)s',
                                       name_fmt='__%s'),
         'l3extRsEctx': ManagedObjectName('l3extOut', 'rsectx'),
+        'l3extRsL3DomAtt': ManagedObjectName('l3extOut', 'l3extRsL3DomAtt'),
         'l3extLNodeP': ManagedObjectName('l3extOut', 'lnodep-%s'),
         'l3extRsNodeL3OutAtt': ManagedObjectName('l3extLNodeP',
                                                  'rsnodeL3OutAtt-[%s]'),
@@ -118,6 +119,7 @@ class ManagedObjectClass(object):
             ManagedObjectName('l3extInstP', 'l3extRsInstPToNatMappingEPg'),
 
         'physDomP': ManagedObjectName(None, 'phys-%s'),
+        'l3extDomP': ManagedObjectName(None, 'l3dom-%s'),
 
         'infraInfra': ManagedObjectName(None, 'infra'),
         'infraNodeP': ManagedObjectName('infraInfra', 'nprof-%(name)s',

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -95,6 +95,17 @@ apic_opts = [
     cfg.StrOpt('vmm_controller_host', default='openstack',
                help='VMM controller IP address or DNS name, used '
                     'for OpenStack VMM'),
+    cfg.StrOpt('apic_external_routed_domain_name',
+               default='${apic_system_id}_l3ext',
+               help=("Name of external routed domain to be created on APIC")),
+    cfg.StrOpt('apic_external_routed_entity_profile',
+               default='${apic_system_id}_l3ext_entity_profile',
+               help=("Name of the entity profile to be created for "
+                     "external routed domain")),
+    cfg.StrOpt('apic_external_routed_function_profile',
+               default='${apic_system_id}_l3ext_function_profile',
+               help=("Name of the function profile to be created for "
+                     "external routed domain")),
 ]
 
 APP_PROFILE_REGEX = "[a-zA-Z0-9_.:-]+"
@@ -229,6 +240,9 @@ class ConfigValidator(object):
         'private_key_file': [valid_file],
         'apic_vmm_type': [valid_apic_name],
         'vmm_controller_host': [valid_controller_host],
+        'apic_external_routed_domain_name': [valid_apic_name],
+        'apic_external_routed_entity_profile': [valid_apic_name],
+        'apic_external_routed_function_profile': [valid_apic_name],
     }
 
     class RaiseUtils(object):

--- a/apicapi/tests/unit/common/test_apic_common.py
+++ b/apicapi/tests/unit/common/test_apic_common.py
@@ -48,10 +48,13 @@ APIC_CONTRACT = 'signedContract'
 
 APIC_SYSTEM_ID = 'sysid'
 APIC_DOMAIN = 'cumuloNimbus'
+APIC_L3EXT_DOMAIN = '%s_l3ext' % APIC_SYSTEM_ID
 
 APIC_NODE_PROF = 'red'
 APIC_FUNC_PROF = 'beta'
 APIC_ATT_ENT_PROF = 'delta'
+APIC_L3EXT_FUNC_PROF = '%s_l3ext_function_profile' % APIC_SYSTEM_ID
+APIC_L3EXT_ATT_ENT_PROF = '%s_l3ext_entity_profile' % APIC_SYSTEM_ID
 APIC_VLAN_NAME = 'gamma'
 APIC_VLANID_FROM = 2900
 APIC_VLANID_TO = 2999
@@ -282,6 +285,16 @@ class ConfigMixin(object):
                 'encap': APIC_EXT_ENCAP,
                 'cidr_exposed': APIC_EXT_CIDR_EXPOSED,
                 'gateway_ip': APIC_EXT_GATEWAY_IP,
+            },
+            APIC_NETWORK + '-1-name': {
+                'switch': APIC_EXT_SWITCH,
+                'port': APIC_EXT_MODULE + '/' + APIC_EXT_PORT,
+                'encap': APIC_EXT_ENCAP,
+                'cidr_exposed': APIC_EXT_CIDR_EXPOSED,
+                'gateway_ip': APIC_EXT_GATEWAY_IP,
+            },
+            APIC_NETWORK + '-pre-name': {
+                'preexisting': 'true',
             },
         }
         self.vlan_ranges = ['physnet1:100:199']


### PR DESCRIPTION
If there are external networks configured, create
external-routed domain, attachable entity-profile,
function profile and access-port selectors.

Signed-off-by: Amit Bose <bose@noironetworks.com>