### PR TITLE
Preventing apic manager to push default configuration when ports are blank

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -297,34 +297,36 @@ class APICManager(object):
                                                  transaction=trs)
                     fpdn = self.get_function_profile(switch, module, port,
                                                      transaction=trs)
-                    self.apic.infraRsAccBaseGrp.create(ppname, hname, 'range',
-                                                       tDn=fpdn,
-                                                       transaction=trs)
-                    self.apic.infraPortBlk.create(ppname, hname, 'range',
-                                                  pbname, fromCard=module,
-                                                  toCard=module,
-                                                  fromPort=str(port),
-                                                  toPort=str(port),
-                                                  transaction=trs)
-                    # Enrich function profile
-                    nname = switch + '-' + port
-                    self.apic.infraConnNodeS.create(
-                        self.function_profile, nname)
-                    self.apic.infraConnNodeBlk.create(
-                        self.function_profile, nname, from_=switch,
-                        to_=switch)
-                    self.apic.infraHConnPortS.create(
-                        self.function_profile, nname, 'range')
-                    self.apic.infraConnPortBlk.create(
-                        self.function_profile, nname, 'range', fromPort=port,
-                        toPort=port)
-                    dn = self.apic.infraHConnPortS.dn(
-                        self.function_profile, nname, 'range')
-                    self.apic.infraRsConnPortS.create(
-                        self.function_profile, nname, dn)
+                    if fpdn:
+                        self.apic.infraRsAccBaseGrp.create(ppname, hname, 'range',
+                                                           tDn=fpdn,
+                                                           transaction=trs)
+                        self.apic.infraPortBlk.create(ppname, hname, 'range',
+                                                      pbname, fromCard=module,
+                                                      toCard=module,
+                                                      fromPort=str(port),
+                                                      toPort=str(port),
+                                                      transaction=trs)
+                        # Enrich function profile
+                        nname = switch + '-' + port
+                        self.apic.infraConnNodeS.create(
+                            self.function_profile, nname)
+                        self.apic.infraConnNodeBlk.create(
+                            self.function_profile, nname, from_=switch,
+                            to_=switch)
+                        self.apic.infraHConnPortS.create(
+                            self.function_profile, nname, 'range')
+                        self.apic.infraConnPortBlk.create(
+                            self.function_profile, nname, 'range', fromPort=port,
+                            toPort=port)
+                        dn = self.apic.infraHConnPortS.dn(
+                            self.function_profile, nname, 'range')
+                        self.apic.infraRsConnPortS.create(
+                            self.function_profile, nname, dn)
 
     def get_function_profile(self, switch, module, port, transaction=None):
-        fpdn = self.apic.infraAccPortGrp.dn(self.function_profile)
+        # If fpdn is not found, let's return None.
+        fpdn = None
         with self.apic.transaction(transaction) as trs:
             if switch in self.vpc_dict:
                 link1 = switch, module, port


### PR DESCRIPTION
This small change fixed a problem we had when restarting the neutron-server.

Thanks!