### PR TITLE
Add config options to apicapi for physical nodes

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -135,6 +135,7 @@ class APICManager(object):
         self.switch_dict = network_config.get('switch_dict', {})
         self.vpc_dict = network_config.get('vpc_dict', {})
         self.ext_net_dict = network_config.get('external_network_dict', {})
+        self.phy_node_segment_dict = config.create_phy_node_segment_dict()
         global LOG
         LOG = log.getLogger(__name__)
 

--- a/apicapi/tests/unit/common/test_apic_common.py
+++ b/apicapi/tests/unit/common/test_apic_common.py
@@ -262,10 +262,15 @@ class ConfigMixin(object):
         self.apic_config = cfg.CONF.ml2_cisco_apic
 
         # Configure switch topology
-        apic_switch_cfg = {
+        apic_mock_cfg = {
             'apic_switch:101': {'ubuntu1,ubuntu2': ['3/11']},
             'apic_switch:102': {'rhel01,rhel02': ['4/21'],
                                 'rhel03': ['4/22']},
+
+            'apic_physical_node_segments': {
+                'rack1': ['host1, host2, host3 '],
+                'rack2': [' host4, , host5'],
+            },
         }
         self.switch_dict = {
             '101': {
@@ -302,8 +307,8 @@ class ConfigMixin(object):
         self.vlan_ranges = ['physnet1:100:199']
         self.mocked_parser = mock.patch.object(
             cfg, 'MultiConfigParser').start()
-        self.mocked_parser.return_value.read.return_value = [apic_switch_cfg]
-        self.mocked_parser.return_value.parsed = [apic_switch_cfg]
+        self.mocked_parser.return_value.read.return_value = [apic_mock_cfg]
+        self.mocked_parser.return_value.parsed = [apic_mock_cfg]
 
     def override_config(self, opt, val, group=None):
         cfg.CONF.set_override(opt, val, group)

--- a/apicapi/tests/unit/test_apic_config.py
+++ b/apicapi/tests/unit/test_apic_config.py
@@ -149,6 +149,22 @@ class TestCiscoApicConfig(base.BaseTestCase, mocked.ConfigMixin):
         self.assertRaises(
             exc.InvalidConfig, self.validator.validate, self.apic_config)
 
+    def test_phy_node_segment_dict(self):
+        node_seg_dict = config.create_phy_node_segment_dict()
+        self.assertEqual(5, len(node_seg_dict))
+        self.assertIsNone(node_seg_dict.get('host0'))
+        self.assertEqual('rack1', node_seg_dict.get('host1'))
+        self.assertEqual('rack1', node_seg_dict.get('host2'))
+        self.assertEqual('rack1', node_seg_dict.get('host3'))
+        self.assertEqual('rack2', node_seg_dict.get('host4'))
+        self.assertEqual('rack2', node_seg_dict.get('host5'))
+
+    def test_valid_encap_mode(self):
+        self._validate('encap_mode', 'vlan')
+        self._validate('encap_mode', 'vxlan')
+        self.assertRaises(
+            exc.InvalidConfig, self._validate, 'encap_mode', 'gre')
+
 
 class TestCiscoApicNewConf(TestCiscoApicConfig):
 


### PR DESCRIPTION
* Added an option to indicate the encapsulation mode
to use for a VMM/physical domain ('encap_mode'). If
unspecified, the encap mode is guessed from other
config options like we do today.
* Added section 'apic_physical_node_segments' which
can be used to associate individual server nodes to
logical segments in the physical network. The format
of options in this section is -
<segment-name>=<comma-separated list of hosts>

Partially-Closes noironetworks/support#113

Signed-off-by: Amit Bose <amitbose@gmail.com>