### PR TITLE
Add config options to apicapi for physical nodes

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -135,6 +135,7 @@ class APICManager(object):
         self.switch_dict = network_config.get('switch_dict', {})
         self.vpc_dict = network_config.get('vpc_dict', {})
         self.ext_net_dict = network_config.get('external_network_dict', {})
+        self.phy_net_dict = config.create_physical_network_dict()
         global LOG
         LOG = log.getLogger(__name__)
 

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -107,6 +107,10 @@ apic_opts = [
                default='${apic_system_id}_l3ext_function_profile',
                help=("Name of the function profile to be created for "
                      "external routed domain")),
+    cfg.StrOpt('encap_mode',
+               help=('Encapsulation to use (vlan, vxlan etc) with APIC '
+                     'domain. If unspecified, encap is inferred from values '
+                     'of other options')),
 ]
 
 
@@ -266,6 +270,13 @@ def valid_controller_host(key, value, **kwargs):
     util.re("%s needs to be set when use_vmm=True" % key)
 
 
+def valid_encap_mode(key, value, **kwargs):
+    util = ConfigValidator.RaiseUtils(value, key)
+    valid = ['vlan', 'vxlan']
+    if value and (value not in valid):
+        util.re("Allowed values: %s" % str(valid))
+
+
 class ConfigValidator(object):
     """Configuration validator for APICAPI.
 
@@ -297,6 +308,7 @@ class ConfigValidator(object):
         'apic_external_routed_domain_name': [valid_apic_name],
         'apic_external_routed_entity_profile': [valid_apic_name],
         'apic_external_routed_function_profile': [valid_apic_name],
+        'encap_mode': [valid_encap_mode],
     }
 
     class RaiseUtils(object):
@@ -407,3 +419,18 @@ def create_physdom_dictionary():
 
 def create_vmdom_dictionary():
     return _create_apic_dom_dictionary('apic_vmdom')
+
+
+def create_physical_network_dict():
+    phy_net_dict = {}
+    conf = _get_specific_config('apic_physical_network')
+    for segment in conf:
+        seg_kv = phy_net_dict.setdefault(segment, {'hosts': set()})
+        for key, value in conf[segment]:
+            if key == 'hosts':
+                host_list = value[0] if value else []
+                host_list = [h.strip() for h in host_list.split(',')]
+                seg_kv['hosts'] = set([h for h in host_list if h])
+            else:
+                seg_kv[key] = value[0] if value else None
+    return phy_net_dict

--- a/apicapi/tests/unit/common/test_apic_common.py
+++ b/apicapi/tests/unit/common/test_apic_common.py
@@ -262,10 +262,17 @@ class ConfigMixin(object):
         self.apic_config = cfg.CONF.ml2_cisco_apic
 
         # Configure switch topology
-        apic_switch_cfg = {
+        apic_mock_cfg = {
             'apic_switch:101': {'ubuntu1,ubuntu2': ['3/11']},
             'apic_switch:102': {'rhel01,rhel02': ['4/21'],
                                 'rhel03': ['4/22']},
+            'apic_physical_network:rack1': {
+                'hosts': ['host1, host2, host3 '],
+                'segment_type': ['vlan'],
+            },
+            'apic_physical_network:rack2': {
+                'hosts': [' host4, , host5'],
+            },
         }
         self.switch_dict = {
             '101': {
@@ -302,8 +309,8 @@ class ConfigMixin(object):
         self.vlan_ranges = ['physnet1:100:199']
         self.mocked_parser = mock.patch.object(
             cfg, 'MultiConfigParser').start()
-        self.mocked_parser.return_value.read.return_value = [apic_switch_cfg]
-        self.mocked_parser.return_value.parsed = [apic_switch_cfg]
+        self.mocked_parser.return_value.read.return_value = [apic_mock_cfg]
+        self.mocked_parser.return_value.parsed = [apic_mock_cfg]
 
     def override_config(self, opt, val, group=None):
         cfg.CONF.set_override(opt, val, group)

--- a/apicapi/tests/unit/test_apic_config.py
+++ b/apicapi/tests/unit/test_apic_config.py
@@ -149,6 +149,21 @@ class TestCiscoApicConfig(base.BaseTestCase, mocked.ConfigMixin):
         self.assertRaises(
             exc.InvalidConfig, self.validator.validate, self.apic_config)
 
+    def test_phy_node_segment_dict(self):
+        phy_net_dict = config.create_physical_network_dict()
+        self.assertEqual(2, len(phy_net_dict))
+        self.assertEqual({'hosts': set(['host1', 'host2', 'host3']),
+                          'segment_type': 'vlan'},
+                         phy_net_dict['rack1'])
+        self.assertEqual({'hosts': set(['host4', 'host5'])},
+                         phy_net_dict['rack2'])
+
+    def test_valid_encap_mode(self):
+        self._validate('encap_mode', 'vlan')
+        self._validate('encap_mode', 'vxlan')
+        self.assertRaises(
+            exc.InvalidConfig, self._validate, 'encap_mode', 'gre')
+
 
 class TestCiscoApicNewConf(TestCiscoApicConfig):
 


### PR DESCRIPTION
* Added an option to indicate the encapsulation mode
to use for a VMM/physical domain ('encap_mode'). If
unspecified, the encap mode is guessed from other
config options like we do today.
* Added section 'apic_physical_network:<net-name>' which
can be used to associate individual server nodes to
logical segments in the physical network. The format
of options in this section is -
hosts=<comma-separated list of hosts>
segment_type=...

Partially-Closes noironetworks/support#113

Signed-off-by: Amit Bose <amitbose@gmail.com>