### PR TITLE
Skip vlan_ranges with no vlans

### DIFF
--- a/apicapi/apic_domain.py
+++ b/apicapi/apic_domain.py
@@ -38,8 +38,9 @@ class ApicDomain(object):
         self.vlan_ranges = self.conf.vlan_ranges
         self.vlan_ns_name = self.conf.apic_vlan_ns_name
         if not self.vlan_ranges and network_config.get('vlan_ranges'):
-            self.vlan_ranges = [':'.join(x.split(':')[-2:]) for x in
-                                network_config.get('vlan_ranges')]
+            self.vlan_ranges = [':'.join(x.split(':')[-2:])
+                                for x in network_config.get('vlan_ranges')
+                                if len(x.split(':')) == 3]
 
         self.encap_mode = self.conf.encap_mode
         if not self.encap_mode:     # guess from other options

--- a/apicapi/tests/unit/common/test_apic_common.py
+++ b/apicapi/tests/unit/common/test_apic_common.py
@@ -306,7 +306,7 @@ class ConfigMixin(object):
                 'preexisting': 'true',
             },
         }
-        self.vlan_ranges = ['physnet1:100:199']
+        self.vlan_ranges = ['physnet0', 'physnet1:100:199']
         self.mocked_parser = mock.patch.object(
             cfg, 'MultiConfigParser').start()
         self.mocked_parser.return_value.read.return_value = [apic_mock_cfg]

--- a/apicapi/tests/unit/test_apic_manager.py
+++ b/apicapi/tests/unit/test_apic_manager.py
@@ -658,7 +658,7 @@ class TestCiscoApicManager(base.BaseTestCase,
         self.override_config('vlan_ranges', [], self.config_group)
         self._initialize_manager()
         self.assertEqual(self.mgr.vlan_ranges,
-                         [':'.join(self.vlan_ranges[0].split(':')[-2:])])
+                         [':'.join(self.vlan_ranges[1].split(':')[-2:])])
 
     def test_auth_url(self):
         mapper = self.mgr._apic_mapper


### PR DESCRIPTION
ML2 allows physnet without vlan's as vlan_ranges. Skip them for apicapi.