### PR TITLE
Updated apic_manager vlan config for no vlans

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -131,8 +131,9 @@ class APICManager(object):
 
         self.vlan_ranges = self.apic_config.vlan_ranges
         if not self.vlan_ranges and network_config.get('vlan_ranges'):
-            self.vlan_ranges = [':'.join(x.split(':')[-2:]) for x in
-                                network_config.get('vlan_ranges')]
+            self.vlan_ranges = [':'.join(x.split(':')[-2:])
+                                for x in network_config.get('vlan_ranges')
+                                if len(x.split(':')) == 3]
 
         self.switch_dict = network_config.get('switch_dict', {})
         self.vpc_dict = network_config.get('vpc_dict', {})

--- a/apicapi/tests/unit/test_apic_manager.py
+++ b/apicapi/tests/unit/test_apic_manager.py
@@ -657,6 +657,8 @@ class TestCiscoApicManager(base.BaseTestCase,
         self.assertEqual(self.mgr.vlan_ranges, vlan_ranges)
         self.override_config('vlan_ranges', [], self.config_group)
         self._initialize_manager()
+        self.assertEqual(self.mgr.vlan_ranges,
+                         [':'.join(self.vlan_ranges[1].split(':')[-2:])])
         self.assertEqual(self.mgr.domains[0].vlan_ranges,
                          [':'.join(self.vlan_ranges[1].split(':')[-2:])])
 


### PR DESCRIPTION
For consistency with apic_domain usage of vlan_ranges with no vlans,
updated logic on apic_manager as well