### PR TITLE
Default_unicast_routing parameter enable.

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -117,6 +117,7 @@ class APICManager(object):
             self.apic_config.enable_optimized_metadata)
         self.default_l2_unknown_unicast = (
             self.apic_config.default_l2_unknown_unicast)
+        self.default_unicast_routing = self.apic_config.default_unicast_routing
         self.default_arp_flooding = self.apic_config.default_arp_flooding
         self.default_ep_move_detect = self.apic_config.default_ep_move_detect
         self.default_enforce_subnet_check = (
@@ -575,7 +576,7 @@ class APICManager(object):
                 unkMacUcastAct=FLOOD_PROXY[
                     self.default_l2_unknown_unicast == 'flood' or
                     allow_broadcast],
-                unicastRoute=YES_NO[unicast_route],
+                unicastRoute=YES_NO[self.default_unicast_routing],
                 epMoveDetectMode=self.default_ep_move_detect,
                 limitIpLearnToSubnets=YES_NO[
                     enforce_subnet_check if enforce_subnet_check is not None

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -31,6 +31,7 @@ apic_opts = [
     cfg.BoolOpt('enable_optimized_dhcp', default=True),
     cfg.BoolOpt('enable_optimized_metadata', default=False),
     cfg.StrOpt('default_l2_unknown_unicast', default='proxy'),
+    cfg.BoolOpt('default_unicast_routing', default=True),
     cfg.BoolOpt('default_arp_flooding', default=True),
     cfg.StrOpt('default_ep_move_detect', default='garp'),
     cfg.BoolOpt('default_enforce_subnet_check', default=False),


### PR DESCRIPTION
This patch enable to change unicast routing setting using config.
If you want to disable default unicast routing , you hava to change parameter default_unicast_routing of apicml2_cisco_conf.ini to False.