### PR TITLE
Allow DN-manager to parse RNs with nested square brackets

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -1038,8 +1038,13 @@ class DNManager(object):
         # surrounding them with parenthesis.
         dn_fmt = '/'.join('(%s)' % x if (x != 'uni' and '-' not in x) else x
                           for x in mo.dn_fmt.split('/'))
+        # this matches upto 1 level of nesting of square brackets
+        # e.g. [foobar] -> OK, matches 'foobar'
+        #      [foo[bar]rr] -> OK, matches 'foo[bar]rr'
+        #      [fo[oo]ba[ar]rr] -> Fails, matches only 'fo[oo]ba[ar'
+        nested_paren_re = '\[([^\[\]]+(?:\[[^\]]+\])*[^\]]*)\]'
         dn_fmt = (dn_fmt.replace('__', '')
-                  .replace('[%s]', '\[([^\]]+)\]')
+                  .replace('[%s]', nested_paren_re)
                   .replace('%s', '([^\/]+)') + '$')
 
         match = re.match(dn_fmt, dn)

--- a/apicapi/tests/unit/test_apic_client.py
+++ b/apicapi/tests/unit/test_apic_client.py
@@ -506,3 +506,13 @@ class TestCiscoApicClient(base.BaseTestCase, mocked.ControllerMixin):
                                         ('vzSubj', 's2'),
                                         ('vzInTerm', 'intmnl'),
                                         ('vzRsFiltAtt', 'f')]))
+
+    def test_aci_decompose_dn_nested_parens(self):
+        manager = self.apic.dn_manager
+        res = manager.aci_decompose(
+            'uni/tn-tenant1/ap-lab/epg-web/rspathAtt-'
+            '[topology/pod-1/paths-101/pathep-[eth1/2]]',
+            'fvRsPathAtt')
+        self.assertEqual(['tenant1', 'lab', 'web',
+                          'topology/pod-1/paths-101/pathep-[eth1/2]'],
+                         res)


### PR DESCRIPTION
Enhanced the regular expression in DN manager to support
limited form of nesting of square brackets. Won't
support arbitrary levels of nesting (which would require
a proper parser), but it should be sufficient to support
current use-cases (for example, DNs of EPG static path binding
objects).

Signed-off-by: Amit Bose <amitbose@gmail.com>