### PR TITLE
Introduce 2 config parameters for keystone notifications

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -123,6 +123,10 @@ class APICManager(object):
             self.apic_config.default_enforce_subnet_check)
         self.default_subnet_scope = self.apic_config.default_subnet_scope
         self.per_tenant_nat_epg = self.apic_config.per_tenant_nat_epg
+        self.keystone_notification_exchange = (self.apic_config.
+                                               keystone_notification_exchange)
+        self.keystone_notification_topic = (self.apic_config.
+                                            keystone_notification_topic)
 
         self.provision_infra = self.apic_config.apic_provision_infra
         self.provision_hostlinks = self.apic_config.apic_provision_hostlinks

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -114,6 +114,14 @@ apic_opts = [
     cfg.BoolOpt('per_tenant_nat_epg', default=False,
                 help=('Whether NAT-ed endpoints should be segregated by '
                       'tenants')),
+    cfg.StrOpt('keystone_notification_exchange',
+               default='keystone',
+               help=("The exchange used to subscribe to Keystone "
+                     "notifications")),
+    cfg.StrOpt('keystone_notification_topic',
+               default='notifications',
+               help=("The topic used to subscribe to Keystone "
+                     "notifications")),
 ]
 
 


### PR DESCRIPTION
If user changes the exchange or topic udner keystone.conf then
they have to change these 2 parameters accordingly.