### PR TITLE
Rollback incomplete vnsConfigIssue support

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -39,7 +39,7 @@ SLEEP_ON_FULL_QUEUE = 1
 
 REFRESH_CODES = [APIC_CODE_FORBIDDEN, ]
 SCOPE = 'openstack_scope'
-MULTI_PARENT = ['faultInst', 'tagInst', 'vnsConfIssue']
+MULTI_PARENT = ['faultInst', 'tagInst']
 DN_BASE = 'uni/'
 
 
@@ -331,7 +331,6 @@ class ManagedObjectClass(object):
     prefix_to_mos['health'] = 'healthInst'
     prefix_to_mos['tag'] = 'tagInst'
     prefix_to_mos['vzSubj'] = 'subj'
-    prefix_to_mos['vnsConfIssue'] = 'vnsConfIssue'
 
     mos_to_prefix = {v: k for k, v in prefix_to_mos.iteritems()}
 

--- a/apicapi/tests/unit/test_apic_client.py
+++ b/apicapi/tests/unit/test_apic_client.py
@@ -550,12 +550,6 @@ class TestCiscoApicClient(base.BaseTestCase, mocked.ControllerMixin):
             'faultInst')
         self.assertEqual(['amit1', 'c', 's2', 'h', 'F1111'], res)
 
-        res = manager.aci_decompose(
-            'uni/tn-common/lDevVip-service__kubernetes/'
-            'vnsConfIssue-missing-cdev/fault-F1690', 'faultInst')
-        self.assertEqual(['common', 'service__kubernetes', 'missing-cdev',
-                          'F1690'], res)
-
     def test_prefix_mos(self):
         prefix_mos = apic.ManagedObjectClass.prefix_to_mos
         self.assertEqual('fvBD', prefix_mos['BD'])


### PR DESCRIPTION
AID should be able to ignore the faults generated with this parent
now.