### PR TITLE
Allow different pod_id and interface_name from the config file

### DIFF
--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -414,6 +414,9 @@ def create_switch_dictionary():
     for switch_id in conf:
         switch_dict[switch_id] = switch_dict.get(switch_id, {})
         for host_list, port in conf[switch_id]:
+            if host_list == 'pod_id':
+                switch_dict[switch_id]['pod_id'] = port[0]
+                continue
             hosts = host_list.split(',')
             hosts = map(lambda a: a.decode('string_escape'), hosts)
             port = port[0]

--- a/apicapi/tests/unit/common/test_apic_common.py
+++ b/apicapi/tests/unit/common/test_apic_common.py
@@ -264,8 +264,9 @@ class ConfigMixin(object):
         # Configure switch topology
         apic_mock_cfg = {
             'apic_switch:101': {'ubuntu1,ubuntu2': ['3/11']},
-            'apic_switch:102': {'rhel01,rhel02': ['4/21'],
-                                'rhel03': ['1/4/22']},
+            'apic_switch:102': {'rhel01|eth1,rhel02|eth2': ['4/21'],
+                                'rhel03|eth3': ['1/4/22'],
+                                'pod_id': '2'},
             'apic_physical_network:rack1': {
                 'hosts': ['host1, host2, host3 '],
                 'segment_type': ['vlan'],
@@ -279,8 +280,9 @@ class ConfigMixin(object):
                 '3/11': ['ubuntu1', 'ubuntu2'],
             },
             '102': {
-                '4/21': ['rhel01', 'rhel02'],
-                '1/4/22': ['rhel03'],
+                '4/21': ['rhel01|eth1', 'rhel02|eth2'],
+                '1/4/22': ['rhel03|eth3'],
+                'pod_id': '2'
             },
         }
         self.vpc_dict = {


### PR DESCRIPTION
1. Here is an example of the new config. Note the pod_id and
eth1/eth2 parameters which are the new things added.

    [apic_switch:401]
    pod_id=2
    f4-compute-2.noiro.lab|eth1=1/34
    f4-compute-1.noiro.lab|eth2=1/33

2. Also add the UTs for this which were compeltely missing before.
3. Also test it out on the real fab for both unified and legacy
plugins to make sure the same set of APIs can support both DB schemas.