### PR TITLE
Don't use cached sessions

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -1387,8 +1387,9 @@ class APICManager(object):
     def update_hostlink_port(self, host, switch, module, port):
         HostLink = self.get_hostlink_class()
         if HostLink:
-            with self.db.session.begin(subtransactions=True):
-                self.db.session.query(HostLink).filter_by(
+            session = self.db.get_session()
+            with session.begin(subtransactions=True):
+                session.query(HostLink).filter_by(
                     host=host,
                     swid=switch,
                     module=module).update({'port': port})
@@ -1396,17 +1397,19 @@ class APICManager(object):
     def get_hostlink_for_switch_module(self, swid, module):
         HostLink = self.get_hostlink_class()
         if HostLink:
-            with self.db.session.begin(subtransactions=True):
-                return self.db.session.query(HostLink).filter_by(
+            session = self.db.get_session()
+            with session.begin(subtransactions=True):
+                return session.query(HostLink).filter_by(
                     swid=swid, module=module).all()
 
     def clear_all_hostlinks(self):
         from sqlalchemy import orm
         HostLink = self.get_hostlink_class()
         if HostLink:
-            with self.db.session.begin(subtransactions=True):
+            session = self.db.get_session()
+            with session.begin(subtransactions=True):
                 try:
-                    self.db.session.query(HostLink).delete()
+                    session.query(HostLink).delete()
                 except orm.exc.NoResultFound:
                     return
 
@@ -1414,9 +1417,10 @@ class APICManager(object):
         from sqlalchemy import orm
         HostLink = self.get_hostlink_class()
         if HostLink:
-            with self.db.session.begin(subtransactions=True):
+            session = self.db.get_session()
+            with session.begin(subtransactions=True):
                 try:
-                    self.db.session.query(HostLink).\
+                    session.query(HostLink).\
                             filter(HostLink.ifname.like('static%')).\
                             delete(synchronize_session=False)
                 except orm.exc.NoResultFound:

--- a/apicapi/tests/db/apic_model.py
+++ b/apicapi/tests/db/apic_model.py
@@ -26,12 +26,12 @@ class ApicDbModel(object):
 
     """DB Model to manage all APIC DB interactions."""
 
-    def __init__(self):
-        self.session = db_api.get_session()
+    def get_session(self, session=None):
+        return session or db_api.get_session()
 
     def get_contract_for_router(self, router_id):
         """Returns the specified router's contract."""
-        return self.session.query().filter_by(
+        return self.get_session().query().filter_by(
             router_id=router_id).first()
 
     def write_contract_for_router(self, tenant_id, router_id):
@@ -39,19 +39,21 @@ class ApicDbModel(object):
         return mock.Mock()
 
     def update_contract_for_router(self, tenant_id, router_id):
-        with self.session.begin(subtransactions=True):
-            contract = self.session.query().filter_by(
+        session = self.get_session()
+        with session.begin(subtransactions=True):
+            contract = session.query().filter_by(
                 router_id=router_id).with_lockmode('update').first()
             if contract:
                 contract.tenant_id = tenant_id
-                self.session.merge(contract)
+                session.merge(contract)
             else:
                 self.write_contract_for_router(tenant_id, router_id)
 
     def delete_contract_for_router(self, router_id):
-        with self.session.begin(subtransactions=True):
+        session = self.get_session()
+        with session.begin(subtransactions=True):
             try:
-                self.session.query().filter_by(
+                session.query().filter_by(
                     router_id=router_id).delete()
             except Exception:
                 return
@@ -60,73 +62,75 @@ class ApicDbModel(object):
         pass
 
     def get_hostlinks(self):
-        return self.session.query().all()
+        return self.get_session().query().all()
 
     def get_hostlink(self, host, ifname):
-        return self.session.query().filter_by(
+        return self.get_session().query().filter_by(
             host=host, ifname=ifname).first()
 
     def get_hostlinks_for_host(self, host):
-        return self.session.query().filter_by(
+        return self.get_session().query().filter_by(
             host=host).all()
 
     def get_hostlinks_for_host_switchport(self, host, swid, module, port):
-        return self.session.query().filter_by(
+        return self.get_session().query().filter_by(
             host=host, swid=swid, module=module, port=port).all()
 
     def get_hostlinks_for_switchport(self, swid, module, port):
-        return self.session.query().filter_by(
+        return self.get_session().query().filter_by(
             swid=swid, module=module, port=port).all()
 
     def delete_hostlink(self, host, ifname):
-        with self.session.begin(subtransactions=True):
+        session = self.get_session()
+        with session.begin(subtransactions=True):
             try:
-                self.session.query().filter_by(host=host,
-                                               ifname=ifname).delete()
+                session.query().filter_by(host=host, ifname=ifname).delete()
             except Exception:
                 return
 
     def get_switches(self):
-        return self.session.query().distinct()
+        return self.get_session().query().distinct()
 
     def get_modules_for_switch(self, swid):
-        return self.session.query().filter_by(swid=swid).distinct()
+        return self.get_session().query().filter_by(swid=swid).distinct()
 
     def get_ports_for_switch_module(self, swid, module):
-        return self.session.query().filter_by(swid=swid,
+        return self.get_session().query().filter_by(swid=swid,
                                               module=module).distinct()
 
     def get_switch_and_port_for_host(self, host):
-        return self.session.query().filter_by(host=host).distinct()
+        return self.get_session().query().filter_by(host=host).distinct()
 
     def get_tenant_network_vlan_for_host(self, host):
-        return self.session.query().filter_by(host=host).distinct()
+        return self.get_session().query().filter_by(host=host).distinct()
 
     def add_apic_name(self, neutron_id, neutron_type, apic_name):
         pass
 
     def update_apic_name(self, neutron_id, neutron_type, apic_name):
-        with self.session.begin(subtransactions=True):
-            name = self.session.query().filter_by(
+        session = self.get_session()
+        with session.begin(subtransactions=True):
+            name = session.query().filter_by(
                 neutron_id=neutron_id,
                 neutron_type=neutron_type).with_lockmode('update').first()
             if name:
                 name.apic_name = apic_name
-                self.session.merge(name)
+                session.merge(name)
             else:
                 self.add_apic_name(neutron_id, neutron_type, apic_name)
 
     def get_apic_names(self):
-        return self.session.query().all()
+        return self.get_session().query().all()
 
     def get_apic_name(self, neutron_id, neutron_type):
-        return self.session.query().filter_by(
+        return self.get_session().query().filter_by(
             neutron_id=neutron_id, neutron_type=neutron_type).first()
 
     def delete_apic_name(self, neutron_id):
-        with self.session.begin(subtransactions=True):
+        session = self.get_session()
+        with session.begin(subtransactions=True):
             try:
-                self.session.query().filter_by(
+                session.query().filter_by(
                     neutron_id=neutron_id).delete()
             except Exception:
                 return


### PR DESCRIPTION
The ApicDbModel was changed in commit 18997b2c1686c12046ec6d7200102e6fcaafc878
to prevent the use of cached sessions. The apicapi library gets passed this model,
and therefore needs to use the new getter method provided to use non-cached sessions.