### PR TITLE
Set upper bound on oslo.config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-oslo.config>=1.4.0  # Apache-2.0
+oslo.config>=1.4.0,<6.0.0  # Apache-2.0
 sqlalchemy
 pyOpenSSL>=16.2.0
 Click>=5.1


### PR DESCRIPTION
The newer versions no longer have MultiConfigParser, which apicapi
uses.