### PR TITLE
Fix semantic versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import setuptools
 
 setuptools.setup(
     name="apicapi",
-    version="1.0.20",
+    version="1.4.0",
     zip_safe=False,
     packages=setuptools.find_packages(exclude=["*.tests", "*.tests.*",
                                                "tests.*", "tests"]),


### PR DESCRIPTION
Previous releases had been created by bumping the patch version.
This patch sets the release to a new minor version, so that the
patch number can be used correctly.