### PR TITLE
Replaced the unicode code in order to pass the pep8.

### DIFF
--- a/apicapi/exceptions.py
+++ b/apicapi/exceptions.py
@@ -30,7 +30,7 @@ class ApicException(Exception):
             super(ApicException, self).__init__(self.message)
 
     def __unicode__(self):
-        return unicode(self.msg)
+        return str(self.msg, 'utf-8')
 
 
 class InvalidConfig(ApicException):


### PR DESCRIPTION
The test "tox -e pep8" failed with unknown symbol unicode
Replaced the line with one that will be compatible with
python3.