### PR TITLE
Get bond interface from environment

### DIFF
--- a/apicapi/tools/bondwatch.py
+++ b/apicapi/tools/bondwatch.py
@@ -11,9 +11,12 @@ import sys
 import time
 
 
+# Get bond interface from environment, else use default
+bondif = os.environ['opflex_bondif'] if os.environ.get(
+    'opflex_bondif') else 'bond0'
 # Default config. First 2 params can be set by command-line args
 config = {
-    'bond-name': 'bond0',
+    'bond-name': bondif,
     'retry-interval': 1,
     'valid-uuid': 0,
     'proc-bond-path': '/proc/net/bonding',

--- a/debian/apic-bond-watch.service
+++ b/debian/apic-bond-watch.service
@@ -7,6 +7,7 @@ Type=simple
 ExecStart=/usr/bin/apic-bond-watch
 KillMode=process
 Restart=always
+EnvironmentFile=-/etc/environment
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/apic-bond-watch.service
+++ b/rpm/apic-bond-watch.service
@@ -7,6 +7,7 @@ Type=simple
 ExecStart=/usr/bin/apic-bond-watch
 KillMode=process
 Restart=always
+EnvironmentFile=-/etc/environment
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Get the bond interface from an environment variable, or else
use the default of bond0.