### PR TITLE
Remove use of message member in Exception objects

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -494,7 +494,7 @@ class ApicSession(object):
                                timeout=self.request_timeout, **kwargs)
             except FALLBACK_EXCEPTIONS as ex:
                 LOG.info(('%s, falling back to a '
-                          'new address'), ex.message)
+                          'new address'), ex)
                 self.api_base.rotate(-1)
                 LOG.info(('New controller address: %s '), self.api_base[0])
         return request(self.api_base[0] + url, verify=self.verify, **kwargs)
@@ -1089,7 +1089,7 @@ class RestClient(ApicSession):
                             map(lambda y: y.renew(), renewable)
                             return True
                         except Exception as e:
-                            LOG.error(e.message)
+                            LOG.error(e)
         return False
 
     @contextlib.contextmanager

--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -376,7 +376,7 @@ class APICManager(object):
         except cexc.ApicResponseNotOk as ex:
             # Ignore for conflicting profiles
             # TODO(ivar): check err_code in the exception
-            LOG.warn(ex.message)
+            LOG.warn(ex)
 
         with self.apic.transaction(transaction) as trs:
             self.ensure_port_profile_created_for_switch(
@@ -1381,7 +1381,7 @@ class APICManager(object):
             __import__(self.apic_model)
             return sys.modules[self.apic_model].HostLink
         except Exception as e:
-            LOG.warn("Couldn't load HostLink class: %s", e.message)
+            LOG.warn("Couldn't load HostLink class: %s", e)
         return None
 
     def update_hostlink_port(self, host, switch, module, port):

--- a/apicapi/config.py
+++ b/apicapi/config.py
@@ -192,7 +192,7 @@ def valid_path(key, value, **kwargs):
         __import__(value)
         sys.modules[value].HostLink
     except Exception as e:
-        ConfigValidator.RaiseUtils(value, key).re(reason=e.message)
+        ConfigValidator.RaiseUtils(value, key).re(reason=e)
 
 
 def not_null(key, value, **kwargs):
@@ -233,7 +233,7 @@ def valid_ip(key, value, **kwargs):
     try:
         netaddr.IPAddress(value, version=4)
     except netaddr.AddrFormatError as e:
-        util.re(reason=e.message)
+        util.re(reason=e)
 
 
 def valid_ip_range(key, value, **kwargs):

--- a/apicapi/tools/bondwatch.py
+++ b/apicapi/tools/bondwatch.py
@@ -31,7 +31,7 @@ logging.basicConfig(
 def err(msg):
     e = sys.exc_info()[1]
     if e is not None:
-        logging.error(':'.join([msg, e.message]))
+        logging.error(':'.join([msg, e]))
     else:
         logging.error(msg)
 

--- a/apicapi/tools/cli/common.py
+++ b/apicapi/tools/cli/common.py
@@ -52,7 +52,7 @@ def pass_apic_client(f):
         except apic_client.rexc.SSLError as e:
             raise click.UsageError(
                 "Command failed with error: %s \nTry using option "
-                "'--no-secure' to skip certificate validation" % e.message)
+                "'--no-secure' to skip certificate validation" % e)
         return f(apic, *args, **kwargs)
     return inner
 

--- a/apicapi/tools/cli/neutron/client.py
+++ b/apicapi/tools/cli/neutron/client.py
@@ -44,6 +44,6 @@ def get_neutron_client(*args, **kwargs):
     try:
         n_shell.authenticate_user()
     except exc.CommandError as e:
-        raise click.BadParameter(e.message)
+        raise click.BadParameter(e)
 
     return n_shell.client_manager.neutron

--- a/apicapi/tools/cli/shell.py
+++ b/apicapi/tools/cli/shell.py
@@ -35,7 +35,7 @@ def neutron_sync(neutron, *args, **kwargs):
     try:
         neutron.create_network({'network': {'name': 'apic-sync-network'}})
     except Exception as e:
-        if message in e.message:
+        if message in e:
             click.echo("Synchronization complete.")
         elif (isinstance(e, n_exc.NeutronClientException) and
               e.status_code == 504):


### PR DESCRIPTION
The current logging code uses the message member from Exception
objects to produce error logs. In anticipation of supporting python3,
which doesn't use this member, we should remove the use of this member,
and instead pass the exception objects directly.