### PR TITLE
Fix re-login to APIC

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -31,13 +31,14 @@ LOG = None
 
 APIC_CODE_FORBIDDEN = str(requests.codes.forbidden)
 APIC_CODE_SSL_ERROR = str(requests.codes.gateway_timeout)
+APIC_CODE_UNAUTHORIZED = str(requests.codes.unauthorized)
 
 FALLBACK_EXCEPTIONS = (rexc.ConnectionError, rexc.Timeout,
                        rexc.TooManyRedirects, rexc.InvalidURL)
 SLEEP_TIME = 0.03
 SLEEP_ON_FULL_QUEUE = 1
 
-REFRESH_CODES = [APIC_CODE_FORBIDDEN, ]
+REFRESH_CODES = (APIC_CODE_FORBIDDEN, APIC_CODE_UNAUTHORIZED, )
 SCOPE = 'openstack_scope'
 MULTI_PARENT = ['faultInst', 'tagInst']
 DN_BASE = 'uni/'

--- a/apicapi/tests/unit/test_apic_client.py
+++ b/apicapi/tests/unit/test_apic_client.py
@@ -181,16 +181,17 @@ class TestCiscoApicClient(base.BaseTestCase, mocked.ControllerMixin):
 
     def test_lookup_mo_bad_token_retry(self):
         self._mock_authenticate()
-        # For the first get request we mock a bad token.
-        self.mock_error_get_response(requests.codes.bad_request,
-                                     code='403',
-                                     text=u'Token was invalid. Expired.')
-        # Client will then try to re-login.
-        self.mock_apic_manager_login_responses()
-        # Then the client will retry to get the tenant.
-        self.mock_response_for_get('fvTenant', name=mocked.APIC_TENANT)
-        tenant = self.apic.fvTenant.get(mocked.APIC_TENANT)
-        self.assertEqual(tenant['name'], mocked.APIC_TENANT)
+        for http_response in ('403', '401'):
+            # For each initial get request we mock a bad token.
+            self.mock_error_get_response(requests.codes.bad_request,
+                                         code=http_response,
+                                         text=u'Token was invalid. Expired.')
+            # Client will then try to re-login.
+            self.mock_apic_manager_login_responses()
+            # Then the client will retry to get the tenant.
+            self.mock_response_for_get('fvTenant', name=mocked.APIC_TENANT)
+            tenant = self.apic.fvTenant.get(mocked.APIC_TENANT)
+            self.assertEqual(tenant['name'], mocked.APIC_TENANT)
 
     def test_lookup_nonexistant_mo(self):
         self._mock_authenticate()


### PR DESCRIPTION
The code to recover from authorization or login failures with
APIC only considers 403 HTTP response codes. This patch adds
the 401 HTTP response code (this was seen when APIC lost its
connection with the AAA server).