### PR TITLE
Add support for other Python3 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,22 @@ matrix:
     - python: 2.7
       env:
         - TOX_ENV=pep8
+    - python: 3.5
+      env:
+        - TOX_ENV=py35
+    - python: 3.5
+      env:
+        - TOX_ENV=pep8
     - python: 3.6
       env:
         - TOX_ENV=py36
     - python: 3.6
+      env:
+        - TOX_ENV=pep8
+    - python: 3.7
+      env:
+        - TOX_ENV=py37
+    - python: 3.7
       env:
         - TOX_ENV=pep8
 install:

--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -1097,16 +1097,19 @@ class RestClient(ApicSession):
 
     @contextlib.contextmanager
     def transaction(self, transaction=None, ph=None, top_send=False):
-        if not transaction:
-            transaction = Transaction(self, top_send=top_send)
-            yield transaction
-            if transaction.root:
-                result = transaction.commit()
-                if ph is not None:
-                    ph.append(result)
-        else:
-            # Only the top owner will commit the transaction
-            yield transaction
+        try:
+            if not transaction:
+                transaction = Transaction(self, top_send=top_send)
+                yield transaction
+                if transaction.root:
+                    result = transaction.commit()
+                    if ph is not None:
+                        ph.append(result)
+            else:
+                # Only the top owner will commit the transaction
+                yield transaction
+        except StopIteration:
+            return
 
 
 class DNManager(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,pep8
+envlist = py27,py35,py36,py37,pep8
 minversion = 1.8
 skipsdist = True
 


### PR DESCRIPTION
Upstream consumers of this repo have different requirements for
python3, depending on their stable branch. Since apicapi doesn't
have stable branches, it must be tested across all supported versions.