### PR TITLE
Updated ERSPAN Mos

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -341,21 +341,18 @@ class ManagedObjectClass(object):
         'spanVSrcGrp__tn': ManagedObjectName('fvTenant', 'vsrcgrp-%s'),
         'spanSpanLbl': ManagedObjectName('spanVSrcGrp', 'spanlbl-%s'),
         'spanVSrc': ManagedObjectName('spanVSrcGrp', 'vsrc-%s'),
-        'spanRsSrcToVPort':
-        ManagedObjectName(
-                'spanVSrc',
-                'rssrcToVPort-[uni/tn-%(name)s/ap-%s/epg-%s/cep-%s]'),
-        'fvCEp': ManagedObjectName('fvAEPg', 'cep-%s'),
+        'spanRsSrcToVPort': ManagedObjectName('spanVSrc', 'rssrcToVPort-[%s]'),
         'spanVDestGrp': ManagedObjectName('infraInfra', 'vdestgrp-%s'),
         'spanVDestGrp__tn': ManagedObjectName('fvTenant', 'vdestgrp-%s'),
         'spanVDest': ManagedObjectName('spanVDestGrp', 'vdest-%s'),
         'spanVEpgSummary': ManagedObjectName('spanVDest', 'vepgsummary'),
-        'infraRsSpanVDestGrp':
-        ManagedObjectName(
-                'infraAccBndlGrp', 'rsspanVDestGrp-%(tnSpanVDestGrpName)s'),
-        'infraRsSpanVSrcGrp':
-        ManagedObjectName(
-                'infraAccBndlGrp', 'rsspanVSrcGrp-%(tnSpanVSrcGrpName)s'),
+        'infraRsSpanVSrcGrp': ManagedObjectName('infraAccBndlGrp',
+                                                'rsspanVSrcGrp-%(name)s',
+                                                name_fmt='__%s'),
+        'infraRsSpanVSrcGrp__ap': ManagedObjectName('infraAccPortGrp',
+                                                    'rsspanVSrcGrp-%(name)s',
+                                                    name_fmt='__%s'),
+
     }
 
     same_rn_types = {'hostprotSubj': ['vzSubj'],


### PR DESCRIPTION
- Removed fvCEp since it was not needed for our usecase.
- Added infraRsSpanVSrcGrp__ap which uses acc port group.
- Removed infraRsSpanVDestGrp since it was not needed for our use case.