### PR TITLE
Add MOs for ERSPAN VPC

### DIFF
--- a/apicapi/apic_client.py
+++ b/apicapi/apic_client.py
@@ -352,6 +352,12 @@ class ManagedObjectClass(object):
         'infraRsSpanVSrcGrp__ap': ManagedObjectName('infraAccPortGrp',
                                                     'rsspanVSrcGrp-%(name)s',
                                                     name_fmt='__%s'),
+        'infraRsSpanVDestGrp': ManagedObjectName('infraAccBndlGrp',
+                                                'rsspanVDestGrp-%(name)s',
+                                                name_fmt='__%s'),
+        'infraRsSpanVDestGrp__ap': ManagedObjectName('infraAccPortGrp',
+                                                    'rsspanVDestGrp-%(name)s',
+                                                    name_fmt='__%s'),
 
     }
 


### PR DESCRIPTION
- We need these two MOs for successfully binding destination groups.