### PR TITLE
Support python2 builds for RHEL7/8

### DIFF
--- a/rpm/apicapi.spec.in
+++ b/rpm/apicapi.spec.in
@@ -7,9 +7,9 @@ URL:		http://github.com/noironetworks/apicapi
 Source:		apicapi-%{version}.tar.gz
 BuildArch:	noarch
 BuildRequires:	python2-devel
-BuildRequires:	python-pbr
-BuildRequires:	python-setuptools
-Requires:	python-oslo-config >= 1.4.0
+BuildRequires:	python2-pbr
+BuildRequires:	python2-setuptools
+Requires:	python2-oslo-config >= 1.4.0
 Requires:	python-click >= 3.3
 
 %description

--- a/rpm/build-rpm.sh
+++ b/rpm/build-rpm.sh
@@ -4,8 +4,8 @@
 BUILD_DIR=${BUILD_DIR:-`pwd`/rpmbuild}
 mkdir -p $BUILD_DIR/BUILD $BUILD_DIR/SOURCES $BUILD_DIR/SPECS $BUILD_DIR/RPMS $BUILD_DIR/SRPMS
 RELEASE=${RELEASE:-1}
-VERSION=`python setup.py --version`
+VERSION=`python2 setup.py --version`
 SPEC_FILE=apicapi.spec
 sed -e "s/@VERSION@/$VERSION/" -e "s/@RELEASE@/$RELEASE/" rpm/$SPEC_FILE.in > $BUILD_DIR/SPECS/$SPEC_FILE
-python setup.py sdist --dist-dir $BUILD_DIR/SOURCES
+python2 setup.py sdist --dist-dir $BUILD_DIR/SOURCES
 rpmbuild --clean -ba --define "_topdir $BUILD_DIR" $BUILD_DIR/SPECS/$SPEC_FILE


### PR DESCRIPTION
Update package names in order to build packages that support both
RHEL7 and RHEL8 for python2.