### PR TITLE
Fix for python3 RPM packaging

### DIFF
--- a/rpm/build-rpm.sh
+++ b/rpm/build-rpm.sh
@@ -18,6 +18,7 @@ rm -rf rpmbuild
 # Prepare build scripts for python3
 cp rpm/apicapi.spec.in .
 
+sed -i "s/python-/python3-/g" rpm/apicapi.spec.in
 sed -i "s/python2/python3/g" rpm/apicapi.spec.in
 sed -i "s/Name:           %{srcname}/Name:           python3-%{srcname}/g" rpm/apicapi.spec.in
 


### PR DESCRIPTION
The click package dependency needs to reference the python3 version.