### PR TITLE
Fix exception messages for python3

### DIFF
--- a/apicapi/apic_manager.py
+++ b/apicapi/apic_manager.py
@@ -376,7 +376,7 @@ class APICManager(object):
         except cexc.ApicResponseNotOk as ex:
             # Ignore for conflicting profiles
             # TODO(ivar): check err_code in the exception
-            LOG.warn(ex.message)
+            LOG.warn(str(ex))
 
         with self.apic.transaction(transaction) as trs:
             self.ensure_port_profile_created_for_switch(
@@ -1381,7 +1381,7 @@ class APICManager(object):
             __import__(self.apic_model)
             return sys.modules[self.apic_model].HostLink
         except Exception as e:
-            LOG.warn("Couldn't load HostLink class: %s", e.message)
+            LOG.warn("Couldn't load HostLink class: %s", str(e))
         return None
 
     def update_hostlink_port(self, host, switch, module, port):

--- a/apicapi/apic_mapper.py
+++ b/apicapi/apic_mapper.py
@@ -158,7 +158,7 @@ class APICNameMapper(object):
                     name = func(inst, context, resource_id)
                 except Exception as e:
                     LOG.warn(("Exception in looking up name %s"), name_type)
-                    LOG.error(e.message)
+                    LOG.error(str(e))
 
                 purged_id = re.sub(r"-+", "-", resource_id)
                 result = purged_id[:inst.min_suffix]

--- a/apicapi/tools/bondwatch.py
+++ b/apicapi/tools/bondwatch.py
@@ -31,7 +31,7 @@ logging.basicConfig(
 def err(msg):
     e = sys.exc_info()[1]
     if e is not None:
-        logging.error(':'.join([msg, e.message]))
+        logging.error(':'.join([msg, str(e)]))
     else:
         logging.error(msg)
 

--- a/apicapi/tools/cli/common.py
+++ b/apicapi/tools/cli/common.py
@@ -52,7 +52,7 @@ def pass_apic_client(f):
         except apic_client.rexc.SSLError as e:
             raise click.UsageError(
                 "Command failed with error: %s \nTry using option "
-                "'--no-secure' to skip certificate validation" % e.message)
+                "'--no-secure' to skip certificate validation" % str(e))
         return f(apic, *args, **kwargs)
     return inner
 

--- a/apicapi/tools/cli/neutron/client.py
+++ b/apicapi/tools/cli/neutron/client.py
@@ -44,6 +44,6 @@ def get_neutron_client(*args, **kwargs):
     try:
         n_shell.authenticate_user()
     except exc.CommandError as e:
-        raise click.BadParameter(e.message)
+        raise click.BadParameter(str(e))
 
     return n_shell.client_manager.neutron

--- a/apicapi/tools/cli/shell.py
+++ b/apicapi/tools/cli/shell.py
@@ -35,7 +35,7 @@ def neutron_sync(neutron, *args, **kwargs):
     try:
         neutron.create_network({'network': {'name': 'apic-sync-network'}})
     except Exception as e:
-        if message in e.message:
+        if message in str(e):
             click.echo("Synchronization complete.")
         elif (isinstance(e, n_exc.NeutronClientException) and
               e.status_code == 504):


### PR DESCRIPTION
In python3, exceptions no longer have a "message" property. Code
that uses the message property must just use the string representation
of the exception, in order to be compatible with both python2 and
python3.