### PR TITLE
Erspan integration with apic cli

### DIFF
--- a/apicapi/tests/unit/_test_shell.py
+++ b/apicapi/tests/unit/_test_shell.py
@@ -38,6 +38,10 @@ class TestShell(base.BaseTestCase):
             '--apic-username', 'admin',
             '--apic-password', 'mydirtylittlesecret',
         ]
+        self.apic_erspan_command_options = [
+            '--neutron_port', '8363df37-1e3d-4848-8dac-c72724ed5019',
+            '--dest_ip', '1.2.3.4',
+            '--flow_id', '1']
         self.neutron = mock.patch(
             'neutronclient.common.clientmanager.ClientManager.neutron').start()
 
@@ -64,3 +68,8 @@ class TestShell(base.BaseTestCase):
         self.assertIsNotNone(result.exception)
         self.assertTrue("'--no-secure' to skip certificate validation" in
                         result.output)
+
+    def test_erspan_create(self):
+        result = self.invoke(shell.apicapi, [
+            'erspan-create'] + self.apic_erspan_command_options)
+        self.assertFalse(result.exception)

--- a/apicapi/tools/cli/shell.py
+++ b/apicapi/tools/cli/shell.py
@@ -14,10 +14,20 @@
 #    under the License.
 
 import click
+import os
+import subprocess
+import time
 
 from apicapi.tools.cli import common
 from apicapi.tools import host_report
 from neutronclient.common import exceptions as n_exc
+from aim.api import resource as aim_resource
+from aim.api import infra as aim_infra_resource
+from aim import aim_manager
+from aim import context as aim_context
+from aim import utils as aim_utils
+from aim.db import api
+from aim import config
 
 
 @click.group()
@@ -91,6 +101,123 @@ def host_report_cmd(*args, **kwargs):
     """Generate a host report for tech support"""
     host_report.main()
 
+
+@apicapi.command(name='erspan-create')
+@click.option('--neutron_port', help='Neutron port UUID')
+@click.option('--dest_ip', help='remote destination ip address')
+@click.option('--flow_id', help='Flow Id', default='1')
+def erspan_cmd(neutron_port, dest_ip, flow_id, *args, **kwargs):
+    global_opts = [
+    config.cfg.StrOpt('apic_system_id',
+                      help="Prefix for APIC domain/names/profiles created"),
+    ]
+    config.CONF.register_opts(global_opts)
+
+    args = ['--config-file','/etc/aim/aim.conf' , '--config-file', '/etc/aim/aimctl.conf']
+    config.CONF(project='aim', args=args)
+
+    ctx = aim_context.AimContext(store=api.get_store(expire_on_commit=True))
+    aimManager = aim_manager.AimManager()
+    mac_addr = subprocess.check_output("openstack port show %s -c mac_address -f value" % neutron_port, shell=True)
+    mac = mac_addr.upper()
+    epg_net_id = subprocess.check_output("openstack port show %s -c network_id -f value" % neutron_port, shell=True)
+    tenant_prj_id = subprocess.check_output("openstack port show %s -c project_id -f value" % neutron_port, shell=True)
+    name_id = subprocess.check_output("openstack port show %s -c id -f value" % neutron_port, shell=True)
+    grp_name=name_id.decode('utf-8').rstrip("\n")
+    fvCEp_dn = 'uni/tn-prj_' + tenant_prj_id.decode('utf-8').rstrip("\n") + '/ap-OpenStack/epg-net_' + epg_net_id.decode('utf-8').rstrip("\n") + '/cep-' + mac.decode('utf-8').rstrip("\n")
+
+    vsrc_grp_aim = aim_resource.SpanVsourceGroup(name=grp_name)
+    aimManager.create(ctx, vsrc_grp_aim)
+    print(vsrc_grp_aim)
+
+    vsrc = aim_resource.SpanVsource(vsg_name=grp_name, name=grp_name)
+    aimManager.create(ctx, vsrc)
+    aimManager.update(ctx, vsrc, src_paths=[fvCEp_dn])
+
+    vdest_grp_aim = aim_resource.SpanVdestGroup(name=grp_name)
+    aimManager.create(ctx, vdest_grp_aim)
+    vdest = aim_resource.SpanVdest(vdg_name=grp_name, name=grp_name)
+    aimManager.create(ctx, vdest)
+    vepgSum = aim_resource.SpanVepgSummary(vdg_name=grp_name, vd_name=grp_name)
+    aimManager.create(ctx, vepgSum)
+    aimManager.update(ctx, vepgSum, dst_ip=dest_ip, flow_id=flow_id)
+
+    check_topology = aimManager.find(ctx, aim_resource.Topology)
+    if not check_topology:
+        topology_aim = aim_resource.Topology()
+        aimManager.create(ctx, topology_aim)
+        time.sleep(5)
+    bundle_path = aimManager.find(ctx, aim_infra_resource.OpflexDevice)
+    fabricpaths=[]
+    for bundle in bundle_path:
+        fabricpaths.append(bundle.fabric_path_dn)
+
+    grpNames=[]
+    for grpname in fabricpaths:
+        lhs, rhs = grpname.split('/pathep-[')
+        grpNames.append(rhs.rstrip("]"))
+    acc_bundle_names = list(set(grpNames))
+
+    for acc_name in acc_bundle_names:
+        time.sleep(2)
+        acc_bndle_grp_aim = aim_resource.InfraAccBundleGroup(name=acc_name)
+        aimManager.update(ctx, acc_bndle_grp_aim, span_vsource_group_names=[grp_name],
+            span_vdest_group_names=[grp_name])
+
+    span_lbl = aim_resource.SpanSpanlbl(vsg_name=grp_name, name=grp_name)
+    aimManager.create(ctx, span_lbl)
+    aimManager.update(ctx, span_lbl, tag='yellow-green')
+
+
+@apicapi.command(name='erspan-delete') 
+@click.option('--neutron_port', help='Neutron port uuid')
+def erspan_cmd_del(neutron_port, *args, **kwargs):
+    global_opts = [
+    config.cfg.StrOpt('apic_system_id',
+                      help="Prefix for APIC domain/names/profiles created"),
+    ]
+    config.CONF.register_opts(global_opts)
+    args = ['--config-file','/etc/aim/aim.conf' , '--config-file', '/etc/aim/aimctl.conf']
+    config.CONF(project='aim', args=args)
+    
+    ctx = aim_context.AimContext(store=api.get_store(expire_on_commit=True))
+    aimManager = aim_manager.AimManager()
+    name_id = subprocess.check_output("openstack port show %s -c id -f value" % neutron_port, shell=True)
+    grp_name=name_id.decode('utf-8').rstrip("\n")
+    
+    bundle_path = aimManager.find(ctx, aim_infra_resource.OpflexDevice)
+    fabricpaths=[]
+    for bundle in bundle_path:
+        fabricpaths.append(bundle.fabric_path_dn)
+
+    grpNames=[]
+    for grpname in fabricpaths:
+        lhs, rhs = grpname.split('/pathep-[')
+        grpNames.append(rhs.rstrip("]"))
+    acc_bundle_names = list(set(grpNames))
+    
+    for acc_name in acc_bundle_names:
+        acc_bndle_grp_aim = aim_resource.InfraAccBundleGroup(name=acc_name)
+        aimManager.update(ctx, acc_bndle_grp_aim, span_vsource_group_names=[],
+            span_vdest_group_names=[])
+                
+    span_lbl = aim_resource.SpanSpanlbl(vsg_name=grp_name, name=grp_name)
+    aimManager.delete(ctx, span_lbl)
+    
+    vsrc = aim_resource.SpanVsource(vsg_name=grp_name, name=grp_name)
+    aimManager.delete(ctx, vsrc)
+    vsrc_grp_aim = aim_resource.SpanVsourceGroup(name=grp_name)
+    aimManager.delete(ctx, vsrc_grp_aim)
+    print("deleted sourceGrp")
+    
+    vepgSum = aim_resource.SpanVepgSummary(vdg_name=grp_name, vd_name=grp_name)
+    aimManager.delete(ctx, vepgSum)
+    vdest = aim_resource.SpanVdest(vdg_name=grp_name, name=grp_name)
+    aimManager.delete(ctx, vdest)
+    vdest_grp_aim = aim_resource.SpanVdestGroup(name=grp_name)
+    vdest_grp_aim = aim_resource.SpanVdestGroup(name=grp_name)
+    aimManager.delete(ctx, vdest_grp_aim)
+    print("deleted destination")
 
 def run():
     apicapi(auto_envvar_prefix='APICAPI')


### PR DESCRIPTION
- Exposing erspan functionality through apic cli.
- Erspan create Usage: apic erspan-create [OPTIONS]
Options:
  --neutron_port   Neutron port uuid
  --dest_ip            destination ip address
  --flow_id            Flow Id
- Erspan delete Usage: apic erspan-delete [OPTIONS]
Options:
  --neutron_port   Neutron port uuid