### PR TITLE
Remove python2 support for debian

### DIFF
--- a/debian/build-deb.sh
+++ b/debian/build-deb.sh
@@ -5,37 +5,11 @@
 BUILD_DIR=${BUILD_DIR:-`pwd`/debbuild}
 mkdir -p $BUILD_DIR
 rm -rf $BUILD_DIR/*
-NAME=`python setup.py --name`
-VERSION=`python setup.py --version`
+NAME=`python3 setup.py --name`
+VERSION=`python3 setup.py --version`
 REVISION=${REVISION:-1}
 
-# Build python2 package
-python setup.py sdist --dist-dir $BUILD_DIR
-SOURCE_FILE=${NAME}-${VERSION}.tar.gz
-tar -C $BUILD_DIR -xf $BUILD_DIR/$SOURCE_FILE
-SOURCE_DIR=$BUILD_DIR/${NAME}-${VERSION}
-
-sed -e "s/@VERSION@/$VERSION/" -e "s/@REVISION@/$REVISION/" ${SOURCE_DIR}/debian/changelog.in > ${SOURCE_DIR}/debian/changelog
-
-mv $BUILD_DIR/$SOURCE_FILE $BUILD_DIR/${NAME}_${VERSION}.orig.tar.gz
-pushd ${SOURCE_DIR}
-debuild -d -us -uc
-popd
-
-
-# Save the python2 package
-cp debbuild/*.deb .
-rm -rf debbuild
-
-# Prepare build scripts for python3
-cp debian/control .
-cp debian/rules .
-sed -i "s/python/python3/g" debian/control
-sed -i "s/Python2.7/Python3/g" debian/control
-sed -i "s/2.7/3.3/g" debian/control
-sed -i "s/python2/python3/g" debian/rules
-
-# Build the python3 package
+# Build the python package
 python3 setup.py sdist --dist-dir $BUILD_DIR
 SOURCE_FILE=${NAME}-${VERSION}.tar.gz
 tar -C $BUILD_DIR -xf $BUILD_DIR/$SOURCE_FILE
@@ -47,7 +21,3 @@ mv $BUILD_DIR/$SOURCE_FILE $BUILD_DIR/${NAME}_${VERSION}.orig.tar.gz
 pushd ${SOURCE_DIR}
 debuild -d -us -uc
 popd
-
-mv control debian/control
-mv rules debian/rules
-mv *.deb debbuild/

--- a/debian/control
+++ b/debian/control
@@ -1,17 +1,17 @@
 Source: apicapi
-Section: python
+Section: python3
 Priority: optional
 Maintainer: Cisco Systems, Inc. <apicapi@noironetworks.com>
-Build-Depends: debhelper (>= 9), python-setuptools (>= 3.3), python-all (>= 2.7),
-               dh-python
+Build-Depends: debhelper (>= 9), python3-setuptools (>= 3.3), python3-all (>= 2.7),
+               dh-python3
 Standards-Version: 3.9.5
 Homepage: http://github.com/noironetworks/apicapi/
 Vcs-Git: git://github.com/noironetworks/apicapi.git
 Vcs-Browser: http://github.com/noironetworks/apicapi/
 
-Package: python-apicapi
+Package: python3-apicapi
 Architecture: all
-Depends: python-click-cli (>=3.3) | python-click (>=6.2), python-oslo.config (>=1.4),
-         ${misc:Depends}, ${python:Depends}
-Description: Python2.7 interface to Cisco APIC APIs
+Depends: python3-click-cli (>=3.3) | python3-click (>=6.2), python3-oslo.config (>=1.4),
+         ${misc:Depends}, ${python3:Depends}
+Description: Python3 interface to Cisco APIC APIs
  Library that provides an interface to the APIC REST APIs

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
 %:
-	dh $@ --with python2 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_clean:
 	dh_clean


### PR DESCRIPTION
Python2 is EOL, so remove support for it in debian builds.